### PR TITLE
Add credential scope update

### DIFF
--- a/sdk/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/sdk/gen/src/mt_2025_01_01_dashboard/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/sdk/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-deployments/auth-credentials/update.ts
+++ b/sdk/gen/src/mt_2025_01_01_dashboard/resources/management/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/sdk/gen/src/mt_2025_01_01_dashboard/resources/provider-deployments/auth-credentials/update.ts
+++ b/sdk/gen/src/mt_2025_01_01_dashboard/resources/provider-deployments/auth-credentials/update.ts
@@ -35,12 +35,18 @@ export type ProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapDashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<DashboardInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/provider-deployments/auth-credentials/update.ts
@@ -37,12 +37,18 @@ export type ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ManagementInstanceProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/provider-deployments/auth-credentials/update.ts
@@ -35,12 +35,18 @@ export type ProviderDeploymentsAuthCredentialsUpdateBody = {
   name?: string | undefined;
   description?: string | undefined;
   metadata?: Record<string, any> | undefined;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
+  scopes?: string[] | undefined;
 };
 
 export let mapProviderDeploymentsAuthCredentialsUpdateBody =
   mtMap.object<ProviderDeploymentsAuthCredentialsUpdateBody>({
     name: mtMap.objectField('name', mtMap.passthrough()),
     description: mtMap.objectField('description', mtMap.passthrough()),
-    metadata: mtMap.objectField('metadata', mtMap.passthrough())
+    metadata: mtMap.objectField('metadata', mtMap.passthrough()),
+    clientId: mtMap.objectField('client_id', mtMap.passthrough()),
+    clientSecret: mtMap.objectField('client_secret', mtMap.passthrough()),
+    scopes: mtMap.objectField('scopes', mtMap.array(mtMap.passthrough()))
   });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Extends the SDK update request shape for provider auth credentials to include `clientId`, `clientSecret`, and `scopes`, which touches credential/secret handling (even though it’s just client-side mapping). Risk is limited to request serialization compatibility with the API.
> 
> **Overview**
> **Adds support for updating OAuth credential fields via the generated SDK.** The `*AuthCredentialsUpdateBody` types and mappers now accept `client_id`, `client_secret`, and `scopes` (string array) in addition to `name`, `description`, and `metadata`.
> 
> This change is applied consistently across both API versions (`mt_2025_01_01_dashboard` and `mt_2026_01_01_magnetar`) and across dashboard/management and non-instance provider-deployment auth-credential update resources.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 787fc5139979a2b22b970cdb6be04b7291f784fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->