### PR TITLE
Add magic mcp endpoints

### DIFF
--- a/examples/typescript-ai-sdk-v4/package.json
+++ b/examples/typescript-ai-sdk-v4/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1",
-    "@metorial/ai-sdk": "^3.0.0",
+    "@metorial/ai-sdk": "^3.0.1",
     "ai": "^4",
     "metorial": "^3.0.0"
   },

--- a/examples/typescript-ai-sdk/package.json
+++ b/examples/typescript-ai-sdk/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.48",
-    "@metorial/ai-sdk": "^3.0.0",
+    "@metorial/ai-sdk": "^3.0.1",
     "ai": "^6.0.0",
     "metorial": "^3.0.0"
   },

--- a/examples/typescript-anthropic/package.json
+++ b/examples/typescript-anthropic/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/anthropic": "^3.0.0",
+    "@metorial/anthropic": "^3.0.1",
     "metorial": "^3.0.0",
     "@anthropic-ai/sdk": "^0.32.1"
   },

--- a/examples/typescript-deepseek/package.json
+++ b/examples/typescript-deepseek/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/deepseek": "^3.0.0",
+    "@metorial/deepseek": "^3.0.1",
     "metorial": "^3.0.0",
     "openai": "^5.3.0"
   },

--- a/examples/typescript-google/package.json
+++ b/examples/typescript-google/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/google": "^3.0.0",
+    "@metorial/google": "^3.0.1",
     "metorial": "^3.0.0",
     "@google/genai": "^1.13.0"
   },

--- a/examples/typescript-langchain/package.json
+++ b/examples/typescript-langchain/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@langchain/anthropic": "^1.4.0",
     "@langchain/core": "^1.1.0",
-    "@metorial/langchain": "^3.0.0",
+    "@metorial/langchain": "^3.0.1",
     "langchain": "^1.4.0",
     "metorial": "^3.0.0"
   },

--- a/examples/typescript-mistral/package.json
+++ b/examples/typescript-mistral/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/mistral": "^3.0.0",
+    "@metorial/mistral": "^3.0.1",
     "metorial": "^3.0.0",
     "@mistralai/mistralai": "^1.7.2"
   },

--- a/examples/typescript-openai-compatible/package.json
+++ b/examples/typescript-openai-compatible/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/openai-compatible": "^3.0.0",
+    "@metorial/openai-compatible": "^3.0.1",
     "metorial": "^3.0.0",
     "openai": "^5.3.0"
   },

--- a/examples/typescript-openai/package.json
+++ b/examples/typescript-openai/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/openai": "^3.0.0",
+    "@metorial/openai": "^3.0.1",
     "metorial": "^3.0.0",
     "openai": "^5.3.0"
   },

--- a/examples/typescript-provider-config/package.json
+++ b/examples/typescript-provider-config/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/openai": "^3.0.0",
+    "@metorial/openai": "^3.0.1",
     "metorial": "^3.0.0",
     "openai": "^5.3.0"
   },

--- a/examples/typescript-quick-start/package.json
+++ b/examples/typescript-quick-start/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.48",
-    "@metorial/ai-sdk": "^3.0.0",
+    "@metorial/ai-sdk": "^3.0.1",
     "ai": "^6.0.0",
     "metorial": "^3.0.0"
   },

--- a/examples/typescript-togetherai/package.json
+++ b/examples/typescript-togetherai/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/togetherai": "^3.0.0",
+    "@metorial/togetherai": "^3.0.1",
     "metorial": "^3.0.0",
     "openai": "^5.3.0"
   },

--- a/examples/typescript-xai/package.json
+++ b/examples/typescript-xai/package.json
@@ -7,7 +7,7 @@
     "start": "bun ./src/index.ts"
   },
   "dependencies": {
-    "@metorial/xai": "^3.0.0",
+    "@metorial/xai": "^3.0.1",
     "metorial": "^3.0.0",
     "openai": "^5.3.0"
   },

--- a/mcp/ai-sdk/CHANGELOG.md
+++ b/mcp/ai-sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @metorial/ai-sdk
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/ai-sdk/package.json
+++ b/mcp/ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/ai-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -35,9 +35,9 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/mcp/anthropic/CHANGELOG.md
+++ b/mcp/anthropic/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @metorial/anthropic
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/openai-compatible@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/anthropic/package.json
+++ b/mcp/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/anthropic",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,10 +29,10 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
-    "@metorial/openai-compatible": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
+    "@metorial/openai-compatible": "^3.0.1"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "*"

--- a/mcp/deepseek/CHANGELOG.md
+++ b/mcp/deepseek/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @metorial/deepseek
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/openai-compatible@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/deepseek/package.json
+++ b/mcp/deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/deepseek",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,10 +29,10 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
-    "@metorial/openai-compatible": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
+    "@metorial/openai-compatible": "^3.0.1"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/mcp/google/CHANGELOG.md
+++ b/mcp/google/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @metorial/google
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/openai-compatible@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/google/package.json
+++ b/mcp/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/google",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,10 +29,10 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
-    "@metorial/openai-compatible": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
+    "@metorial/openai-compatible": "^3.0.1"
   },
   "peerDependencies": {
     "@google/genai": "*"

--- a/mcp/langchain/CHANGELOG.md
+++ b/mcp/langchain/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @metorial/langchain
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/langchain/package.json
+++ b/mcp/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/langchain",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,9 +29,9 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
     "zod": "^3.22.4"
   },
   "peerDependencies": {

--- a/mcp/mcp-session/CHANGELOG.md
+++ b/mcp/mcp-session/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @metorial/mcp-session
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/mcp-session/package.json
+++ b/mcp/mcp-session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/mcp-session",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@metorial/json-schema": "^3.0.0",
-    "@metorial/core": "^3.0.0",
+    "@metorial/core": "^3.0.1",
     "@metorial/generated": "^3.0.0",
     "@metorial/util-endpoint": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/mcp/mistral/CHANGELOG.md
+++ b/mcp/mistral/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @metorial/mistral
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/mistral/package.json
+++ b/mcp/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/mistral",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,9 +29,9 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1"
   },
   "peerDependencies": {
     "@mistralai/mistralai": "*"

--- a/mcp/openai-compatible/CHANGELOG.md
+++ b/mcp/openai-compatible/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @metorial/openai-compatible
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/openai-compatible/package.json
+++ b/mcp/openai-compatible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/openai-compatible",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,9 +29,9 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/mcp/openai/CHANGELOG.md
+++ b/mcp/openai/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @metorial/openai
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/openai-compatible@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/openai/package.json
+++ b/mcp/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/openai",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,10 +29,10 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
-    "@metorial/openai-compatible": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
+    "@metorial/openai-compatible": "^3.0.1"
   },
   "peerDependencies": {
     "openai": "*"

--- a/mcp/togetherai/CHANGELOG.md
+++ b/mcp/togetherai/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @metorial/togetherai
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/openai-compatible@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/togetherai/package.json
+++ b/mcp/togetherai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/togetherai",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,10 +29,10 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
-    "@metorial/openai-compatible": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
+    "@metorial/openai-compatible": "^3.0.1"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/mcp/xai/CHANGELOG.md
+++ b/mcp/xai/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @metorial/xai
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-sdk-utils@3.0.1
+  - @metorial/openai-compatible@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/mcp/xai/package.json
+++ b/mcp/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/xai",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,10 +29,10 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-sdk-utils": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
-    "@metorial/openai-compatible": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-sdk-utils": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
+    "@metorial/openai-compatible": "^3.0.1"
   },
   "peerDependencies": {},
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,6 @@
     "mcp/*",
     "packages/*",
     "examples/*",
-    "examples/v1/*",
-    "examples/v2/*",
     "sdk/*"
   ],
   "dependencies": {}

--- a/packages/mcp-sdk-utils/CHANGELOG.md
+++ b/packages/mcp-sdk-utils/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @metorial/mcp-sdk-utils
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/mcp-session@3.0.1
+  - @metorial/core@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/mcp-sdk-utils/package.json
+++ b/packages/mcp-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/mcp-sdk-utils",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,8 +29,8 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0"
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1"
   },
   "peerDependencies": {
     "ai": "*"

--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @metorial/core
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+
 ## 3.0.0
 
 ### Major Changes

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/core",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",

--- a/sdk/core/src/index.ts
+++ b/sdk/core/src/index.ts
@@ -103,4 +103,5 @@ export namespace MetorialSDK {
   export type MagicMcpGroup = MetorialGenerated.MagicMcpGroupsGetOutput;
   export type MagicMcpSession = MetorialGenerated.MagicMcpSessionsGetOutput;
   export type MagicMcpToken = MetorialGenerated.MagicMcpTokensGetOutput;
+  export type MagicMcpEndpoint = MetorialGenerated.MagicMcpEndpointsGetOutput;
 }

--- a/sdk/core/src/sdk.ts
+++ b/sdk/core/src/sdk.ts
@@ -20,6 +20,7 @@ import {
   MetorialIntegrationsInstancesProvidersEndpoint,
   MetorialIntegrationsProvidersEndpoint,
   MetorialIntegrationsSetupSessionsEndpoint,
+  MetorialMagicMcpEndpointsEndpoint,
   MetorialMagicMcpGroupsEndpoint,
   MetorialMagicMcpServersEndpoint,
   MetorialMagicMcpServersProvidersEndpoint,
@@ -232,7 +233,8 @@ export let createMetorialCoreSDK = coreSdkBuilder.build(
     }),
     groups: new MetorialMagicMcpGroupsEndpoint(manager),
     sessions: new MetorialMagicMcpSessionsEndpoint(manager),
-    tokens: new MetorialMagicMcpTokensEndpoint(manager)
+    tokens: new MetorialMagicMcpTokensEndpoint(manager),
+    endpoints: new MetorialMagicMcpEndpointsEndpoint(manager)
   },
 
   portals: Object.assign(new MetorialPortalsEndpoint(manager), {

--- a/sdk/sdk/CHANGELOG.md
+++ b/sdk/sdk/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @metorial/sdk
 
+## 3.0.1
+
+### Patch Changes
+
+- Expose magic mcp endpoints
+- Updated dependencies
+  - @metorial/openai-compatible@3.0.1
+  - @metorial/mcp-session@3.0.1
+  - @metorial/togetherai@3.0.1
+  - @metorial/anthropic@3.0.1
+  - @metorial/deepseek@3.0.1
+  - @metorial/mistral@3.0.1
+  - @metorial/google@3.0.1
+  - @metorial/openai@3.0.1
+  - @metorial/core@3.0.1
+  - @metorial/xai@3.0.1
+
 ## 3.0.0
 
 ### Major Changes

--- a/sdk/sdk/package.json
+++ b/sdk/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,17 +29,17 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.0",
-    "@metorial/mcp-session": "^3.0.0",
+    "@metorial/core": "^3.0.1",
+    "@metorial/mcp-session": "^3.0.1",
     "@metorial/util-endpoint": "^3.0.0",
-    "@metorial/anthropic": "^3.0.0",
-    "@metorial/deepseek": "^3.0.0",
-    "@metorial/google": "^3.0.0",
-    "@metorial/mistral": "^3.0.0",
-    "@metorial/openai": "^3.0.0",
-    "@metorial/openai-compatible": "^3.0.0",
-    "@metorial/togetherai": "^3.0.0",
-    "@metorial/xai": "^3.0.0"
+    "@metorial/anthropic": "^3.0.1",
+    "@metorial/deepseek": "^3.0.1",
+    "@metorial/google": "^3.0.1",
+    "@metorial/mistral": "^3.0.1",
+    "@metorial/openai": "^3.0.1",
+    "@metorial/openai-compatible": "^3.0.1",
+    "@metorial/togetherai": "^3.0.1",
+    "@metorial/xai": "^3.0.1"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.30.0",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the public SDK surface by adding `magicMcp.endpoints` and updates workspace/package versions across many packages; however the code changes are small and largely wiring/version bumps.
> 
> **Overview**
> **Exposes Magic MCP endpoints in the TypeScript SDK.** `@metorial/core` now exports a `MagicMcpEndpoint` type and registers a new `magicMcp.endpoints` client (`MetorialMagicMcpEndpointsEndpoint`) alongside existing `servers/groups/sessions/tokens`.
> 
> Releases a `3.0.1` patch across MCP-related packages (`@metorial/*`) with changelog entries and internal dependency bumps, and updates all affected examples to consume `^3.0.1`. The root workspace config also drops `examples/v1/*` and `examples/v2/*` from `workspaces`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83dc7ee7e2911d54991dec27b18f569da86dd294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->