### PR TITLE
Sync clients

### DIFF
--- a/mcp/ai-sdk/package.json
+++ b/mcp/ai-sdk/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "zod": "^3.22.4"

--- a/mcp/anthropic/package.json
+++ b/mcp/anthropic/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/deepseek/package.json
+++ b/mcp/deepseek/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/google/package.json
+++ b/mcp/google/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/langchain/package.json
+++ b/mcp/langchain/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "zod": "^3.22.4"

--- a/mcp/mcp-session/package.json
+++ b/mcp/mcp-session/package.json
@@ -30,8 +30,8 @@
   ],
   "dependencies": {
     "@metorial/json-schema": "^3.0.0",
-    "@metorial/core": "^3.0.1",
-    "@metorial/generated": "^3.0.0",
+    "@metorial/core": "^3.0.2",
+    "@metorial/generated": "^3.0.2",
     "@metorial/util-endpoint": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.12.1",
     "eventsource-parser": "^3.0.0"

--- a/mcp/mistral/package.json
+++ b/mcp/mistral/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1"
   },

--- a/mcp/openai-compatible/package.json
+++ b/mcp/openai-compatible/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1"
   },

--- a/mcp/openai/package.json
+++ b/mcp/openai/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/togetherai/package.json
+++ b/mcp/togetherai/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/xai/package.json
+++ b/mcp/xai/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/packages/mcp-sdk-utils/package.json
+++ b/packages/mcp-sdk-utils/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-session": "^3.0.1"
   },
   "peerDependencies": {

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/core",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/generated": "^3.0.0",
+    "@metorial/generated": "^3.0.2",
     "@metorial/util-endpoint": "^3.0.0"
   },
   "devDependencies": {

--- a/sdk/gen/package.json
+++ b/sdk/gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/generated",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/custom-providers.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/custom-providers.ts
@@ -6,6 +6,7 @@ import {
 import {
   mapDashboardInstanceCustomProvidersCreateBody,
   mapDashboardInstanceCustomProvidersCreateOutput,
+  mapDashboardInstanceCustomProvidersGetEnvOutput,
   mapDashboardInstanceCustomProvidersGetOutput,
   mapDashboardInstanceCustomProvidersListOutput,
   mapDashboardInstanceCustomProvidersListQuery,
@@ -13,6 +14,7 @@ import {
   mapDashboardInstanceCustomProvidersUpdateOutput,
   type DashboardInstanceCustomProvidersCreateBody,
   type DashboardInstanceCustomProvidersCreateOutput,
+  type DashboardInstanceCustomProvidersGetEnvOutput,
   type DashboardInstanceCustomProvidersGetOutput,
   type DashboardInstanceCustomProvidersListOutput,
   type DashboardInstanceCustomProvidersListQuery,
@@ -101,6 +103,33 @@ export class MetorialCustomProvidersEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider environment
+   * @description Retrieves the environment variables for a specific custom provider by ID.
+   *
+   * @param `customProviderId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    customProviderId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersGetEnvOutput> {
+    let path = `custom-providers/${customProviderId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersGetEnvOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/custom-providers_versions.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/custom-providers_versions.ts
@@ -6,11 +6,13 @@ import {
 import {
   mapDashboardInstanceCustomProvidersVersionsCreateBody,
   mapDashboardInstanceCustomProvidersVersionsCreateOutput,
+  mapDashboardInstanceCustomProvidersVersionsGetEnvOutput,
   mapDashboardInstanceCustomProvidersVersionsGetOutput,
   mapDashboardInstanceCustomProvidersVersionsListOutput,
   mapDashboardInstanceCustomProvidersVersionsListQuery,
   type DashboardInstanceCustomProvidersVersionsCreateBody,
   type DashboardInstanceCustomProvidersVersionsCreateOutput,
+  type DashboardInstanceCustomProvidersVersionsGetEnvOutput,
   type DashboardInstanceCustomProvidersVersionsGetOutput,
   type DashboardInstanceCustomProvidersVersionsListOutput,
   type DashboardInstanceCustomProvidersVersionsListQuery
@@ -99,6 +101,33 @@ export class MetorialCustomProvidersVersionsEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersVersionsGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider version environment
+   * @description Retrieves the environment variables for a specific version of a custom provider.
+   *
+   * @param `customProviderVersionId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersVersionsGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    customProviderVersionId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersVersionsGetEnvOutput> {
+    let path = `custom-provider-versions/${customProviderVersionId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersVersionsGetEnvOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/dashboard_instance_custom-providers.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/dashboard_instance_custom-providers.ts
@@ -6,6 +6,7 @@ import {
 import {
   mapDashboardInstanceCustomProvidersCreateBody,
   mapDashboardInstanceCustomProvidersCreateOutput,
+  mapDashboardInstanceCustomProvidersGetEnvOutput,
   mapDashboardInstanceCustomProvidersGetOutput,
   mapDashboardInstanceCustomProvidersListOutput,
   mapDashboardInstanceCustomProvidersListQuery,
@@ -13,6 +14,7 @@ import {
   mapDashboardInstanceCustomProvidersUpdateOutput,
   type DashboardInstanceCustomProvidersCreateBody,
   type DashboardInstanceCustomProvidersCreateOutput,
+  type DashboardInstanceCustomProvidersGetEnvOutput,
   type DashboardInstanceCustomProvidersGetOutput,
   type DashboardInstanceCustomProvidersListOutput,
   type DashboardInstanceCustomProvidersListQuery,
@@ -105,6 +107,35 @@ export class MetorialDashboardInstanceCustomProvidersEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider environment
+   * @description Retrieves the environment variables for a specific custom provider by ID.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersGetEnvOutput> {
+    let path = `dashboard/instances/${instanceId}/custom-providers/${customProviderId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersGetEnvOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/dashboard_instance_custom-providers_versions.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/dashboard_instance_custom-providers_versions.ts
@@ -6,11 +6,13 @@ import {
 import {
   mapDashboardInstanceCustomProvidersVersionsCreateBody,
   mapDashboardInstanceCustomProvidersVersionsCreateOutput,
+  mapDashboardInstanceCustomProvidersVersionsGetEnvOutput,
   mapDashboardInstanceCustomProvidersVersionsGetOutput,
   mapDashboardInstanceCustomProvidersVersionsListOutput,
   mapDashboardInstanceCustomProvidersVersionsListQuery,
   type DashboardInstanceCustomProvidersVersionsCreateBody,
   type DashboardInstanceCustomProvidersVersionsCreateOutput,
+  type DashboardInstanceCustomProvidersVersionsGetEnvOutput,
   type DashboardInstanceCustomProvidersVersionsGetOutput,
   type DashboardInstanceCustomProvidersVersionsListOutput,
   type DashboardInstanceCustomProvidersVersionsListQuery
@@ -103,6 +105,35 @@ export class MetorialDashboardInstanceCustomProvidersVersionsEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersVersionsGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider version environment
+   * @description Retrieves the environment variables for a specific version of a custom provider.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderVersionId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersVersionsGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderVersionId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersVersionsGetEnvOutput> {
+    let path = `dashboard/instances/${instanceId}/custom-provider-versions/${customProviderVersionId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersVersionsGetEnvOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/dashboard_instance_portals_consumer-profiles.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/dashboard_instance_portals_consumer-profiles.ts
@@ -6,6 +6,8 @@ import {
 import {
   mapDashboardInstancePortalsConsumerProfilesAssignGroupsBody,
   mapDashboardInstancePortalsConsumerProfilesAssignGroupsOutput,
+  mapDashboardInstancePortalsConsumerProfilesCreateBody,
+  mapDashboardInstancePortalsConsumerProfilesCreateOutput,
   mapDashboardInstancePortalsConsumerProfilesGetOutput,
   mapDashboardInstancePortalsConsumerProfilesListOutput,
   mapDashboardInstancePortalsConsumerProfilesListQuery,
@@ -13,6 +15,8 @@ import {
   mapDashboardInstancePortalsConsumerProfilesUnassignGroupsOutput,
   type DashboardInstancePortalsConsumerProfilesAssignGroupsBody,
   type DashboardInstancePortalsConsumerProfilesAssignGroupsOutput,
+  type DashboardInstancePortalsConsumerProfilesCreateBody,
+  type DashboardInstancePortalsConsumerProfilesCreateOutput,
   type DashboardInstancePortalsConsumerProfilesGetOutput,
   type DashboardInstancePortalsConsumerProfilesListOutput,
   type DashboardInstancePortalsConsumerProfilesListQuery,
@@ -111,6 +115,40 @@ export class MetorialDashboardInstancePortalsConsumerProfilesEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstancePortalsConsumerProfilesGetOutput
+    );
+  }
+
+  /**
+   * @name Create portal consumer profile
+   * @description Creates a new portal consumer profile.
+   *
+   * @param `instanceId` - string
+   * @param `portalId` - string
+   * @param `body` - DashboardInstancePortalsConsumerProfilesCreateBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstancePortalsConsumerProfilesCreateOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  create(
+    instanceId: string,
+    portalId: string,
+    body: DashboardInstancePortalsConsumerProfilesCreateBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstancePortalsConsumerProfilesCreateOutput> {
+    let path = `dashboard/instances/${instanceId}/portals/${portalId}/consumer-profile`;
+
+    let request = {
+      path,
+      body: mapDashboardInstancePortalsConsumerProfilesCreateBody.transformTo(
+        body
+      ),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._post(request).transform(
+      mapDashboardInstancePortalsConsumerProfilesCreateOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/management_instance_custom-providers.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/management_instance_custom-providers.ts
@@ -6,6 +6,7 @@ import {
 import {
   mapDashboardInstanceCustomProvidersCreateBody,
   mapDashboardInstanceCustomProvidersCreateOutput,
+  mapDashboardInstanceCustomProvidersGetEnvOutput,
   mapDashboardInstanceCustomProvidersGetOutput,
   mapDashboardInstanceCustomProvidersListOutput,
   mapDashboardInstanceCustomProvidersListQuery,
@@ -13,6 +14,7 @@ import {
   mapDashboardInstanceCustomProvidersUpdateOutput,
   type DashboardInstanceCustomProvidersCreateBody,
   type DashboardInstanceCustomProvidersCreateOutput,
+  type DashboardInstanceCustomProvidersGetEnvOutput,
   type DashboardInstanceCustomProvidersGetOutput,
   type DashboardInstanceCustomProvidersListOutput,
   type DashboardInstanceCustomProvidersListQuery,
@@ -105,6 +107,35 @@ export class MetorialManagementInstanceCustomProvidersEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider environment
+   * @description Retrieves the environment variables for a specific custom provider by ID.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersGetEnvOutput> {
+    let path = `instances/${instanceId}/custom-providers/${customProviderId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersGetEnvOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/management_instance_custom-providers_versions.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/management_instance_custom-providers_versions.ts
@@ -6,11 +6,13 @@ import {
 import {
   mapDashboardInstanceCustomProvidersVersionsCreateBody,
   mapDashboardInstanceCustomProvidersVersionsCreateOutput,
+  mapDashboardInstanceCustomProvidersVersionsGetEnvOutput,
   mapDashboardInstanceCustomProvidersVersionsGetOutput,
   mapDashboardInstanceCustomProvidersVersionsListOutput,
   mapDashboardInstanceCustomProvidersVersionsListQuery,
   type DashboardInstanceCustomProvidersVersionsCreateBody,
   type DashboardInstanceCustomProvidersVersionsCreateOutput,
+  type DashboardInstanceCustomProvidersVersionsGetEnvOutput,
   type DashboardInstanceCustomProvidersVersionsGetOutput,
   type DashboardInstanceCustomProvidersVersionsListOutput,
   type DashboardInstanceCustomProvidersVersionsListQuery
@@ -103,6 +105,35 @@ export class MetorialManagementInstanceCustomProvidersVersionsEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstanceCustomProvidersVersionsGetOutput
+    );
+  }
+
+  /**
+   * @name Get custom provider version environment
+   * @description Retrieves the environment variables for a specific version of a custom provider.
+   *
+   * @param `instanceId` - string
+   * @param `customProviderVersionId` - string
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstanceCustomProvidersVersionsGetEnvOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  getEnv(
+    instanceId: string,
+    customProviderVersionId: string,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstanceCustomProvidersVersionsGetEnvOutput> {
+    let path = `instances/${instanceId}/custom-provider-versions/${customProviderVersionId}/env`;
+
+    let request = {
+      path,
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._get(request).transform(
+      mapDashboardInstanceCustomProvidersVersionsGetEnvOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/management_instance_portals_consumer-profiles.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/management_instance_portals_consumer-profiles.ts
@@ -6,6 +6,8 @@ import {
 import {
   mapDashboardInstancePortalsConsumerProfilesAssignGroupsBody,
   mapDashboardInstancePortalsConsumerProfilesAssignGroupsOutput,
+  mapDashboardInstancePortalsConsumerProfilesCreateBody,
+  mapDashboardInstancePortalsConsumerProfilesCreateOutput,
   mapDashboardInstancePortalsConsumerProfilesGetOutput,
   mapDashboardInstancePortalsConsumerProfilesListOutput,
   mapDashboardInstancePortalsConsumerProfilesListQuery,
@@ -13,6 +15,8 @@ import {
   mapDashboardInstancePortalsConsumerProfilesUnassignGroupsOutput,
   type DashboardInstancePortalsConsumerProfilesAssignGroupsBody,
   type DashboardInstancePortalsConsumerProfilesAssignGroupsOutput,
+  type DashboardInstancePortalsConsumerProfilesCreateBody,
+  type DashboardInstancePortalsConsumerProfilesCreateOutput,
   type DashboardInstancePortalsConsumerProfilesGetOutput,
   type DashboardInstancePortalsConsumerProfilesListOutput,
   type DashboardInstancePortalsConsumerProfilesListQuery,
@@ -111,6 +115,40 @@ export class MetorialManagementInstancePortalsConsumerProfilesEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstancePortalsConsumerProfilesGetOutput
+    );
+  }
+
+  /**
+   * @name Create portal consumer profile
+   * @description Creates a new portal consumer profile.
+   *
+   * @param `instanceId` - string
+   * @param `portalId` - string
+   * @param `body` - DashboardInstancePortalsConsumerProfilesCreateBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstancePortalsConsumerProfilesCreateOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  create(
+    instanceId: string,
+    portalId: string,
+    body: DashboardInstancePortalsConsumerProfilesCreateBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstancePortalsConsumerProfilesCreateOutput> {
+    let path = `instances/${instanceId}/portals/${portalId}/consumer-profile`;
+
+    let request = {
+      path,
+      body: mapDashboardInstancePortalsConsumerProfilesCreateBody.transformTo(
+        body
+      ),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._post(request).transform(
+      mapDashboardInstancePortalsConsumerProfilesCreateOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/portals_consumer-profiles.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/endpoints/portals_consumer-profiles.ts
@@ -6,6 +6,8 @@ import {
 import {
   mapDashboardInstancePortalsConsumerProfilesAssignGroupsBody,
   mapDashboardInstancePortalsConsumerProfilesAssignGroupsOutput,
+  mapDashboardInstancePortalsConsumerProfilesCreateBody,
+  mapDashboardInstancePortalsConsumerProfilesCreateOutput,
   mapDashboardInstancePortalsConsumerProfilesGetOutput,
   mapDashboardInstancePortalsConsumerProfilesListOutput,
   mapDashboardInstancePortalsConsumerProfilesListQuery,
@@ -13,6 +15,8 @@ import {
   mapDashboardInstancePortalsConsumerProfilesUnassignGroupsOutput,
   type DashboardInstancePortalsConsumerProfilesAssignGroupsBody,
   type DashboardInstancePortalsConsumerProfilesAssignGroupsOutput,
+  type DashboardInstancePortalsConsumerProfilesCreateBody,
+  type DashboardInstancePortalsConsumerProfilesCreateOutput,
   type DashboardInstancePortalsConsumerProfilesGetOutput,
   type DashboardInstancePortalsConsumerProfilesListOutput,
   type DashboardInstancePortalsConsumerProfilesListQuery,
@@ -107,6 +111,38 @@ export class MetorialPortalsConsumerProfilesEndpoint {
 
     return this._get(request).transform(
       mapDashboardInstancePortalsConsumerProfilesGetOutput
+    );
+  }
+
+  /**
+   * @name Create portal consumer profile
+   * @description Creates a new portal consumer profile.
+   *
+   * @param `portalId` - string
+   * @param `body` - DashboardInstancePortalsConsumerProfilesCreateBody
+   * @param `opts` - { headers?: Record<string, string> }
+   * @returns DashboardInstancePortalsConsumerProfilesCreateOutput
+   * @see https://metorial.com/api
+   * @see https://metorial.com/docs
+   */
+  create(
+    portalId: string,
+    body: DashboardInstancePortalsConsumerProfilesCreateBody,
+    opts?: { headers?: Record<string, string> }
+  ): Promise<DashboardInstancePortalsConsumerProfilesCreateOutput> {
+    let path = `portals/${portalId}/consumer-profile`;
+
+    let request = {
+      path,
+      body: mapDashboardInstancePortalsConsumerProfilesCreateBody.transformTo(
+        body
+      ),
+
+      ...(opts?.headers ? { headers: opts.headers } : {})
+    } as any;
+
+    return this._post(request).transform(
+      mapDashboardInstancePortalsConsumerProfilesCreateOutput
     );
   }
 

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/get-env.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type CustomProvidersGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapCustomProvidersGetEnvOutput =
+  mtMap.object<CustomProvidersGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/index.ts
@@ -2,6 +2,7 @@ export * from './commits';
 export * from './create';
 export * from './deployments';
 export * from './environments';
+export * from './get-env';
 export * from './get';
 export * from './list';
 export * from './update';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/versions/get-env.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/versions/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type CustomProvidersVersionsGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapCustomProvidersVersionsGetEnvOutput =
+  mtMap.object<CustomProvidersVersionsGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/versions/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/custom-providers/versions/index.ts
@@ -1,3 +1,4 @@
 export * from './create';
+export * from './get-env';
 export * from './get';
 export * from './list';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/get-env.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceCustomProvidersGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapDashboardInstanceCustomProvidersGetEnvOutput =
+  mtMap.object<DashboardInstanceCustomProvidersGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/index.ts
@@ -2,6 +2,7 @@ export * from './commits';
 export * from './create';
 export * from './deployments';
 export * from './environments';
+export * from './get-env';
 export * from './get';
 export * from './list';
 export * from './update';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/versions/get-env.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/versions/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstanceCustomProvidersVersionsGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapDashboardInstanceCustomProvidersVersionsGetEnvOutput =
+  mtMap.object<DashboardInstanceCustomProvidersVersionsGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/versions/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/custom-providers/versions/index.ts
@@ -1,3 +1,4 @@
 export * from './create';
+export * from './get-env';
 export * from './get';
 export * from './list';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instance-groups/create-session-template.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instance-groups/create-session-template.ts
@@ -10,6 +10,8 @@ export type DashboardInstanceIntegrationsInstanceGroupsCreateSessionTemplateOutp
     metadata: Record<string, any> | null;
     integrationInstanceId: string | null;
     integrationInstanceGroupId: string | null;
+    identityActorId: string | null;
+    identityId: string | null;
     providers: {
       object: 'session.template.provider';
       id: string;
@@ -77,6 +79,11 @@ export let mapDashboardInstanceIntegrationsInstanceGroupsCreateSessionTemplateOu
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instance-groups/create-session.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instance-groups/create-session.ts
@@ -69,6 +69,8 @@ export type DashboardInstanceIntegrationsInstanceGroupsCreateSessionOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapDashboardInstanceIntegrationsInstanceGroupsCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instances/create-session-template.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instances/create-session-template.ts
@@ -10,6 +10,8 @@ export type DashboardInstanceIntegrationsInstancesCreateSessionTemplateOutput =
     metadata: Record<string, any> | null;
     integrationInstanceId: string | null;
     integrationInstanceGroupId: string | null;
+    identityActorId: string | null;
+    identityId: string | null;
     providers: {
       object: 'session.template.provider';
       id: string;
@@ -77,6 +79,11 @@ export let mapDashboardInstanceIntegrationsInstancesCreateSessionTemplateOutput 
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instances/create-session.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/integrations/instances/create-session.ts
@@ -69,6 +69,8 @@ export type DashboardInstanceIntegrationsInstancesCreateSessionOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapDashboardInstanceIntegrationsInstancesCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/consumer-profiles/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/consumer-profiles/create.ts
@@ -1,0 +1,96 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type DashboardInstancePortalsConsumerProfilesCreateOutput = {
+  object: 'consumer.profile';
+  id: string;
+  name: string;
+  email: string;
+  imageUrl: string;
+  consumerId: string;
+  status: 'active' | 'invited';
+  createdAt: Date;
+  updatedAt: Date;
+} & {
+  groups:
+    | {
+        object: 'consumer.profile.group_assignment';
+        group: {
+          object: 'consumer.group';
+          id: string;
+          status: 'active' | 'archived' | 'deleted';
+          name: string;
+          description: string | null;
+          isDefault: boolean;
+          ssoGroupIds: string[];
+          createdAt: Date;
+          updatedAt: Date;
+        };
+        assignedVia: 'default' | 'manual' | 'sso' | 'user';
+      }[]
+    | null;
+};
+
+export let mapDashboardInstancePortalsConsumerProfilesCreateOutput =
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        email: mtMap.objectField('email', mtMap.passthrough()),
+        imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+        consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        groups: mtMap.objectField(
+          'groups',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              group: mtMap.objectField(
+                'group',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  ssoGroupIds: mtMap.objectField(
+                    'sso_group_ids',
+                    mtMap.array(mtMap.passthrough())
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              assignedVia: mtMap.objectField(
+                'assigned_via',
+                mtMap.passthrough()
+              )
+            })
+          )
+        )
+      })
+    )
+  ]);
+
+export type DashboardInstancePortalsConsumerProfilesCreateBody = {
+  email: string;
+  name: string;
+};
+
+export let mapDashboardInstancePortalsConsumerProfilesCreateBody =
+  mtMap.object<DashboardInstancePortalsConsumerProfilesCreateBody>({
+    email: mtMap.objectField('email', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/consumer-profiles/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/consumer-profiles/index.ts
@@ -1,4 +1,5 @@
 export * from './assign-groups';
+export * from './create';
 export * from './get';
 export * from './list';
 export * from './unassign-groups';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/create.ts
@@ -17,7 +17,11 @@ export type DashboardInstancePortalsCreateOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapDashboardInstancePortalsCreateOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/delete.ts
@@ -17,7 +17,11 @@ export type DashboardInstancePortalsDeleteOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapDashboardInstancePortalsDeleteOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/get.ts
@@ -17,7 +17,11 @@ export type DashboardInstancePortalsGetOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapDashboardInstancePortalsGetOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/list.ts
@@ -18,7 +18,11 @@ export type DashboardInstancePortalsListOutput = {
       allowedFileExtensions: string[];
       allowNonStandardDirectories: boolean;
     };
-    auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+    auth: {
+      object: 'portal.auth';
+      sessionExpiryTimeInSeconds: number;
+      allowedRedirectUrlFilters: { url: string }[];
+    };
     urls: { type: 'default'; url: string }[];
     createdAt: Date;
     updatedAt: Date;
@@ -73,6 +77,14 @@ export let mapDashboardInstancePortalsListOutput =
               sessionExpiryTimeInSeconds: mtMap.objectField(
                 'session_expiry_time_in_seconds',
                 mtMap.passthrough()
+              ),
+              allowedRedirectUrlFilters: mtMap.objectField(
+                'allowed_redirect_url_filters',
+                mtMap.array(
+                  mtMap.object({
+                    url: mtMap.objectField('url', mtMap.passthrough())
+                  })
+                )
               )
             })
           ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/portals/update.ts
@@ -17,7 +17,11 @@ export type DashboardInstancePortalsUpdateOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapDashboardInstancePortalsUpdateOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/create.ts
@@ -9,6 +9,8 @@ export type DashboardInstanceSessionTemplatesCreateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapDashboardInstanceSessionTemplatesCreateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/delete.ts
@@ -9,6 +9,8 @@ export type DashboardInstanceSessionTemplatesDeleteOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapDashboardInstanceSessionTemplatesDeleteOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/get.ts
@@ -9,6 +9,8 @@ export type DashboardInstanceSessionTemplatesGetOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapDashboardInstanceSessionTemplatesGetOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/list.ts
@@ -10,6 +10,8 @@ export type DashboardInstanceSessionTemplatesListOutput = {
     metadata: Record<string, any> | null;
     integrationInstanceId: string | null;
     integrationInstanceGroupId: string | null;
+    identityActorId: string | null;
+    identityId: string | null;
     providers: {
       object: 'session.template.provider';
       id: string;
@@ -82,6 +84,11 @@ export let mapDashboardInstanceSessionTemplatesListOutput =
             'integration_instance_group_id',
             mtMap.passthrough()
           ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           providers: mtMap.objectField(
             'providers',
             mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/session-templates/update.ts
@@ -9,6 +9,8 @@ export type DashboardInstanceSessionTemplatesUpdateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapDashboardInstanceSessionTemplatesUpdateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/connections/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/connections/get.ts
@@ -27,6 +27,8 @@ export type DashboardInstanceSessionsConnectionsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -98,6 +100,8 @@ export let mapDashboardInstanceSessionsConnectionsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/connections/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/connections/list.ts
@@ -28,6 +28,8 @@ export type DashboardInstanceSessionsConnectionsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -112,6 +114,11 @@ export let mapDashboardInstanceSessionsConnectionsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/create.ts
@@ -69,6 +69,8 @@ export type DashboardInstanceSessionsCreateOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapDashboardInstanceSessionsCreateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/delete.ts
@@ -69,6 +69,8 @@ export type DashboardInstanceSessionsDeleteOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapDashboardInstanceSessionsDeleteOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/events/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/events/get.ts
@@ -44,6 +44,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -123,6 +125,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -139,6 +143,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -196,6 +202,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -212,6 +220,8 @@ export type DashboardInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -333,6 +343,11 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -497,6 +512,14 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
                   'identity_actor_id',
                   mtMap.passthrough()
                 ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
+                  mtMap.passthrough()
+                ),
                 agentClientId: mtMap.objectField(
                   'agent_client_id',
                   mtMap.passthrough()
@@ -544,6 +567,14 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
                 ),
                 identityActorId: mtMap.objectField(
                   'identity_actor_id',
+                  mtMap.passthrough()
+                ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
                   mtMap.passthrough()
                 ),
                 agentClientId: mtMap.objectField(
@@ -682,6 +713,11 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -720,6 +756,11 @@ export let mapDashboardInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/events/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/events/list.ts
@@ -45,6 +45,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -124,6 +126,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -140,6 +144,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -200,6 +206,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -216,6 +224,8 @@ export type DashboardInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -349,6 +359,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -540,6 +558,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                         'identity_actor_id',
                         mtMap.passthrough()
                       ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
+                        mtMap.passthrough()
+                      ),
                       agentClientId: mtMap.objectField(
                         'agent_client_id',
                         mtMap.passthrough()
@@ -590,6 +616,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                       ),
                       identityActorId: mtMap.objectField(
                         'identity_actor_id',
+                        mtMap.passthrough()
+                      ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
                         mtMap.passthrough()
                       ),
                       agentClientId: mtMap.objectField(
@@ -749,6 +783,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -796,6 +838,14 @@ export let mapDashboardInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/get.ts
@@ -69,6 +69,8 @@ export type DashboardInstanceSessionsGetOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapDashboardInstanceSessionsGetOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/list.ts
@@ -70,6 +70,8 @@ export type DashboardInstanceSessionsListOutput = {
     fromTemplatesIds: string[];
     hasErrors: boolean;
     hasWarnings: boolean;
+    identityActorId: string | null;
+    identityId: string | null;
     createdAt: Date;
     updatedAt: Date;
   }[];
@@ -256,6 +258,11 @@ export let mapDashboardInstanceSessionsListOutput =
           ),
           hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
           hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/messages/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/messages/get.ts
@@ -57,6 +57,8 @@ export type DashboardInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -73,6 +75,8 @@ export type DashboardInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -124,6 +128,8 @@ export type DashboardInstanceSessionsMessagesGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -140,6 +146,8 @@ export type DashboardInstanceSessionsMessagesGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -277,6 +285,11 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -315,6 +328,11 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -438,6 +456,8 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -475,6 +495,8 @@ export let mapDashboardInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/messages/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/messages/list.ts
@@ -58,6 +58,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -74,6 +76,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -131,6 +135,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -147,6 +153,8 @@ export type DashboardInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -302,6 +310,14 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -349,6 +365,14 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -490,6 +514,11 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -528,6 +557,11 @@ export let mapDashboardInstanceSessionsMessagesListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/participants/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/participants/get.ts
@@ -12,6 +12,8 @@ export type DashboardInstanceSessionsParticipantsGetOutput = {
   agentId: string | null;
   agentInstanceId: string | null;
   identityActorId: string | null;
+  identityId: string | null;
+  agentActorId: string | null;
   agentClientId: string | null;
   consumerId: string | null;
   createdAt: Date;
@@ -42,6 +44,8 @@ export let mapDashboardInstanceSessionsParticipantsGetOutput =
       'identity_actor_id',
       mtMap.passthrough()
     ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
     agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
     consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date())

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/participants/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/participants/list.ts
@@ -13,6 +13,8 @@ export type DashboardInstanceSessionsParticipantsListOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -50,6 +52,11 @@ export let mapDashboardInstanceSessionsParticipantsListOutput =
           ),
           identityActorId: mtMap.objectField(
             'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
             mtMap.passthrough()
           ),
           agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/sessions/update.ts
@@ -69,6 +69,8 @@ export type DashboardInstanceSessionsUpdateOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapDashboardInstanceSessionsUpdateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/tool-calls/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/tool-calls/create.ts
@@ -25,6 +25,8 @@ export type DashboardInstanceToolCallsCreateOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -41,6 +43,8 @@ export type DashboardInstanceToolCallsCreateOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -127,6 +131,8 @@ export let mapDashboardInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -164,6 +170,8 @@ export let mapDashboardInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/tool-calls/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/tool-calls/get.ts
@@ -25,6 +25,8 @@ export type DashboardInstanceToolCallsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -41,6 +43,8 @@ export type DashboardInstanceToolCallsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -127,6 +131,8 @@ export let mapDashboardInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -164,6 +170,8 @@ export let mapDashboardInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/tool-calls/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/dashboard/instance/tool-calls/list.ts
@@ -26,6 +26,8 @@ export type DashboardInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -42,6 +44,8 @@ export type DashboardInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -140,6 +144,11 @@ export let mapDashboardInstanceToolCallsListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -178,6 +187,11 @@ export let mapDashboardInstanceToolCallsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instance-groups/create-session-template.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instance-groups/create-session-template.ts
@@ -9,6 +9,8 @@ export type IntegrationsInstanceGroupsCreateSessionTemplateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapIntegrationsInstanceGroupsCreateSessionTemplateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instance-groups/create-session.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instance-groups/create-session.ts
@@ -69,6 +69,8 @@ export type IntegrationsInstanceGroupsCreateSessionOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapIntegrationsInstanceGroupsCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instances/create-session-template.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instances/create-session-template.ts
@@ -9,6 +9,8 @@ export type IntegrationsInstancesCreateSessionTemplateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapIntegrationsInstancesCreateSessionTemplateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instances/create-session.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/integrations/instances/create-session.ts
@@ -69,6 +69,8 @@ export type IntegrationsInstancesCreateSessionOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapIntegrationsInstancesCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/get-env.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type ManagementInstanceCustomProvidersGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapManagementInstanceCustomProvidersGetEnvOutput =
+  mtMap.object<ManagementInstanceCustomProvidersGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/index.ts
@@ -2,6 +2,7 @@ export * from './commits';
 export * from './create';
 export * from './deployments';
 export * from './environments';
+export * from './get-env';
 export * from './get';
 export * from './list';
 export * from './update';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/versions/get-env.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/versions/get-env.ts
@@ -1,0 +1,13 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type ManagementInstanceCustomProvidersVersionsGetEnvOutput = {
+  object: 'custom_provider.env';
+  env: Record<string, any> | null;
+};
+
+export let mapManagementInstanceCustomProvidersVersionsGetEnvOutput =
+  mtMap.object<ManagementInstanceCustomProvidersVersionsGetEnvOutput>({
+    object: mtMap.objectField('object', mtMap.passthrough()),
+    env: mtMap.objectField('env', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/versions/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/custom-providers/versions/index.ts
@@ -1,3 +1,4 @@
 export * from './create';
+export * from './get-env';
 export * from './get';
 export * from './list';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instance-groups/create-session-template.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instance-groups/create-session-template.ts
@@ -10,6 +10,8 @@ export type ManagementInstanceIntegrationsInstanceGroupsCreateSessionTemplateOut
     metadata: Record<string, any> | null;
     integrationInstanceId: string | null;
     integrationInstanceGroupId: string | null;
+    identityActorId: string | null;
+    identityId: string | null;
     providers: {
       object: 'session.template.provider';
       id: string;
@@ -77,6 +79,11 @@ export let mapManagementInstanceIntegrationsInstanceGroupsCreateSessionTemplateO
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instance-groups/create-session.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instance-groups/create-session.ts
@@ -69,6 +69,8 @@ export type ManagementInstanceIntegrationsInstanceGroupsCreateSessionOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -232,6 +234,11 @@ export let mapManagementInstanceIntegrationsInstanceGroupsCreateSessionOutput =
       ),
       hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
       hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date()),
       updatedAt: mtMap.objectField('updated_at', mtMap.date())
     }

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instances/create-session-template.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instances/create-session-template.ts
@@ -10,6 +10,8 @@ export type ManagementInstanceIntegrationsInstancesCreateSessionTemplateOutput =
     metadata: Record<string, any> | null;
     integrationInstanceId: string | null;
     integrationInstanceGroupId: string | null;
+    identityActorId: string | null;
+    identityId: string | null;
     providers: {
       object: 'session.template.provider';
       id: string;
@@ -77,6 +79,11 @@ export let mapManagementInstanceIntegrationsInstancesCreateSessionTemplateOutput
         'integration_instance_group_id',
         mtMap.passthrough()
       ),
+      identityActorId: mtMap.objectField(
+        'identity_actor_id',
+        mtMap.passthrough()
+      ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
       providers: mtMap.objectField(
         'providers',
         mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instances/create-session.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/integrations/instances/create-session.ts
@@ -69,6 +69,8 @@ export type ManagementInstanceIntegrationsInstancesCreateSessionOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapManagementInstanceIntegrationsInstancesCreateSessionOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/consumer-profiles/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/consumer-profiles/create.ts
@@ -1,0 +1,96 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type ManagementInstancePortalsConsumerProfilesCreateOutput = {
+  object: 'consumer.profile';
+  id: string;
+  name: string;
+  email: string;
+  imageUrl: string;
+  consumerId: string;
+  status: 'active' | 'invited';
+  createdAt: Date;
+  updatedAt: Date;
+} & {
+  groups:
+    | {
+        object: 'consumer.profile.group_assignment';
+        group: {
+          object: 'consumer.group';
+          id: string;
+          status: 'active' | 'archived' | 'deleted';
+          name: string;
+          description: string | null;
+          isDefault: boolean;
+          ssoGroupIds: string[];
+          createdAt: Date;
+          updatedAt: Date;
+        };
+        assignedVia: 'default' | 'manual' | 'sso' | 'user';
+      }[]
+    | null;
+};
+
+export let mapManagementInstancePortalsConsumerProfilesCreateOutput =
+  mtMap.union([
+    mtMap.unionOption(
+      'object',
+      mtMap.object({
+        object: mtMap.objectField('object', mtMap.passthrough()),
+        id: mtMap.objectField('id', mtMap.passthrough()),
+        name: mtMap.objectField('name', mtMap.passthrough()),
+        email: mtMap.objectField('email', mtMap.passthrough()),
+        imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+        consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+        status: mtMap.objectField('status', mtMap.passthrough()),
+        createdAt: mtMap.objectField('created_at', mtMap.date()),
+        updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+        groups: mtMap.objectField(
+          'groups',
+          mtMap.array(
+            mtMap.object({
+              object: mtMap.objectField('object', mtMap.passthrough()),
+              group: mtMap.objectField(
+                'group',
+                mtMap.object({
+                  object: mtMap.objectField('object', mtMap.passthrough()),
+                  id: mtMap.objectField('id', mtMap.passthrough()),
+                  status: mtMap.objectField('status', mtMap.passthrough()),
+                  name: mtMap.objectField('name', mtMap.passthrough()),
+                  description: mtMap.objectField(
+                    'description',
+                    mtMap.passthrough()
+                  ),
+                  isDefault: mtMap.objectField(
+                    'is_default',
+                    mtMap.passthrough()
+                  ),
+                  ssoGroupIds: mtMap.objectField(
+                    'sso_group_ids',
+                    mtMap.array(mtMap.passthrough())
+                  ),
+                  createdAt: mtMap.objectField('created_at', mtMap.date()),
+                  updatedAt: mtMap.objectField('updated_at', mtMap.date())
+                })
+              ),
+              assignedVia: mtMap.objectField(
+                'assigned_via',
+                mtMap.passthrough()
+              )
+            })
+          )
+        )
+      })
+    )
+  ]);
+
+export type ManagementInstancePortalsConsumerProfilesCreateBody = {
+  email: string;
+  name: string;
+};
+
+export let mapManagementInstancePortalsConsumerProfilesCreateBody =
+  mtMap.object<ManagementInstancePortalsConsumerProfilesCreateBody>({
+    email: mtMap.objectField('email', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/consumer-profiles/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/consumer-profiles/index.ts
@@ -1,4 +1,5 @@
 export * from './assign-groups';
+export * from './create';
 export * from './get';
 export * from './list';
 export * from './unassign-groups';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/create.ts
@@ -17,7 +17,11 @@ export type ManagementInstancePortalsCreateOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapManagementInstancePortalsCreateOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/delete.ts
@@ -17,7 +17,11 @@ export type ManagementInstancePortalsDeleteOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapManagementInstancePortalsDeleteOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/get.ts
@@ -17,7 +17,11 @@ export type ManagementInstancePortalsGetOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapManagementInstancePortalsGetOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/list.ts
@@ -18,7 +18,11 @@ export type ManagementInstancePortalsListOutput = {
       allowedFileExtensions: string[];
       allowNonStandardDirectories: boolean;
     };
-    auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+    auth: {
+      object: 'portal.auth';
+      sessionExpiryTimeInSeconds: number;
+      allowedRedirectUrlFilters: { url: string }[];
+    };
     urls: { type: 'default'; url: string }[];
     createdAt: Date;
     updatedAt: Date;
@@ -73,6 +77,14 @@ export let mapManagementInstancePortalsListOutput =
               sessionExpiryTimeInSeconds: mtMap.objectField(
                 'session_expiry_time_in_seconds',
                 mtMap.passthrough()
+              ),
+              allowedRedirectUrlFilters: mtMap.objectField(
+                'allowed_redirect_url_filters',
+                mtMap.array(
+                  mtMap.object({
+                    url: mtMap.objectField('url', mtMap.passthrough())
+                  })
+                )
               )
             })
           ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/portals/update.ts
@@ -17,7 +17,11 @@ export type ManagementInstancePortalsUpdateOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -63,6 +67,12 @@ export let mapManagementInstancePortalsUpdateOutput =
         sessionExpiryTimeInSeconds: mtMap.objectField(
           'session_expiry_time_in_seconds',
           mtMap.passthrough()
+        ),
+        allowedRedirectUrlFilters: mtMap.objectField(
+          'allowed_redirect_url_filters',
+          mtMap.array(
+            mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+          )
         )
       })
     ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/create.ts
@@ -9,6 +9,8 @@ export type ManagementInstanceSessionTemplatesCreateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapManagementInstanceSessionTemplatesCreateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/delete.ts
@@ -9,6 +9,8 @@ export type ManagementInstanceSessionTemplatesDeleteOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapManagementInstanceSessionTemplatesDeleteOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/get.ts
@@ -9,6 +9,8 @@ export type ManagementInstanceSessionTemplatesGetOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapManagementInstanceSessionTemplatesGetOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/list.ts
@@ -10,6 +10,8 @@ export type ManagementInstanceSessionTemplatesListOutput = {
     metadata: Record<string, any> | null;
     integrationInstanceId: string | null;
     integrationInstanceGroupId: string | null;
+    identityActorId: string | null;
+    identityId: string | null;
     providers: {
       object: 'session.template.provider';
       id: string;
@@ -82,6 +84,11 @@ export let mapManagementInstanceSessionTemplatesListOutput =
             'integration_instance_group_id',
             mtMap.passthrough()
           ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           providers: mtMap.objectField(
             'providers',
             mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/session-templates/update.ts
@@ -9,6 +9,8 @@ export type ManagementInstanceSessionTemplatesUpdateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapManagementInstanceSessionTemplatesUpdateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/connections/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/connections/get.ts
@@ -27,6 +27,8 @@ export type ManagementInstanceSessionsConnectionsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -98,6 +100,8 @@ export let mapManagementInstanceSessionsConnectionsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/connections/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/connections/list.ts
@@ -28,6 +28,8 @@ export type ManagementInstanceSessionsConnectionsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -112,6 +114,11 @@ export let mapManagementInstanceSessionsConnectionsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/create.ts
@@ -69,6 +69,8 @@ export type ManagementInstanceSessionsCreateOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapManagementInstanceSessionsCreateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/delete.ts
@@ -69,6 +69,8 @@ export type ManagementInstanceSessionsDeleteOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapManagementInstanceSessionsDeleteOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/events/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/events/get.ts
@@ -44,6 +44,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -123,6 +125,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -139,6 +143,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -196,6 +202,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -212,6 +220,8 @@ export type ManagementInstanceSessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -333,6 +343,11 @@ export let mapManagementInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -497,6 +512,14 @@ export let mapManagementInstanceSessionsEventsGetOutput =
                   'identity_actor_id',
                   mtMap.passthrough()
                 ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
+                  mtMap.passthrough()
+                ),
                 agentClientId: mtMap.objectField(
                   'agent_client_id',
                   mtMap.passthrough()
@@ -544,6 +567,14 @@ export let mapManagementInstanceSessionsEventsGetOutput =
                 ),
                 identityActorId: mtMap.objectField(
                   'identity_actor_id',
+                  mtMap.passthrough()
+                ),
+                identityId: mtMap.objectField(
+                  'identity_id',
+                  mtMap.passthrough()
+                ),
+                agentActorId: mtMap.objectField(
+                  'agent_actor_id',
                   mtMap.passthrough()
                 ),
                 agentClientId: mtMap.objectField(
@@ -682,6 +713,11 @@ export let mapManagementInstanceSessionsEventsGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -720,6 +756,11 @@ export let mapManagementInstanceSessionsEventsGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/events/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/events/list.ts
@@ -45,6 +45,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -124,6 +126,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -140,6 +144,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -200,6 +206,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -216,6 +224,8 @@ export type ManagementInstanceSessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -349,6 +359,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -540,6 +558,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                         'identity_actor_id',
                         mtMap.passthrough()
                       ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
+                        mtMap.passthrough()
+                      ),
                       agentClientId: mtMap.objectField(
                         'agent_client_id',
                         mtMap.passthrough()
@@ -590,6 +616,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                       ),
                       identityActorId: mtMap.objectField(
                         'identity_actor_id',
+                        mtMap.passthrough()
+                      ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
                         mtMap.passthrough()
                       ),
                       agentClientId: mtMap.objectField(
@@ -749,6 +783,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -796,6 +838,14 @@ export let mapManagementInstanceSessionsEventsListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/get.ts
@@ -69,6 +69,8 @@ export type ManagementInstanceSessionsGetOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapManagementInstanceSessionsGetOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/list.ts
@@ -70,6 +70,8 @@ export type ManagementInstanceSessionsListOutput = {
     fromTemplatesIds: string[];
     hasErrors: boolean;
     hasWarnings: boolean;
+    identityActorId: string | null;
+    identityId: string | null;
     createdAt: Date;
     updatedAt: Date;
   }[];
@@ -256,6 +258,11 @@ export let mapManagementInstanceSessionsListOutput =
           ),
           hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
           hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           createdAt: mtMap.objectField('created_at', mtMap.date()),
           updatedAt: mtMap.objectField('updated_at', mtMap.date())
         })

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/messages/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/messages/get.ts
@@ -57,6 +57,8 @@ export type ManagementInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -73,6 +75,8 @@ export type ManagementInstanceSessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -124,6 +128,8 @@ export type ManagementInstanceSessionsMessagesGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -140,6 +146,8 @@ export type ManagementInstanceSessionsMessagesGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -277,6 +285,11 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -315,6 +328,11 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -438,6 +456,8 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -475,6 +495,8 @@ export let mapManagementInstanceSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/messages/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/messages/list.ts
@@ -58,6 +58,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -74,6 +76,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -131,6 +135,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -147,6 +153,8 @@ export type ManagementInstanceSessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -302,6 +310,14 @@ export let mapManagementInstanceSessionsMessagesListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -349,6 +365,14 @@ export let mapManagementInstanceSessionsMessagesListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -490,6 +514,11 @@ export let mapManagementInstanceSessionsMessagesListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -528,6 +557,11 @@ export let mapManagementInstanceSessionsMessagesListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/participants/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/participants/get.ts
@@ -12,6 +12,8 @@ export type ManagementInstanceSessionsParticipantsGetOutput = {
   agentId: string | null;
   agentInstanceId: string | null;
   identityActorId: string | null;
+  identityId: string | null;
+  agentActorId: string | null;
   agentClientId: string | null;
   consumerId: string | null;
   createdAt: Date;
@@ -42,6 +44,8 @@ export let mapManagementInstanceSessionsParticipantsGetOutput =
       'identity_actor_id',
       mtMap.passthrough()
     ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
     agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
     consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date())

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/participants/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/participants/list.ts
@@ -13,6 +13,8 @@ export type ManagementInstanceSessionsParticipantsListOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -50,6 +52,11 @@ export let mapManagementInstanceSessionsParticipantsListOutput =
           ),
           identityActorId: mtMap.objectField(
             'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
             mtMap.passthrough()
           ),
           agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/sessions/update.ts
@@ -69,6 +69,8 @@ export type ManagementInstanceSessionsUpdateOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -222,6 +224,11 @@ export let mapManagementInstanceSessionsUpdateOutput =
     ),
     hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
     hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date()),
     updatedAt: mtMap.objectField('updated_at', mtMap.date())
   });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/tool-calls/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/tool-calls/create.ts
@@ -25,6 +25,8 @@ export type ManagementInstanceToolCallsCreateOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -41,6 +43,8 @@ export type ManagementInstanceToolCallsCreateOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -127,6 +131,8 @@ export let mapManagementInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -164,6 +170,8 @@ export let mapManagementInstanceToolCallsCreateOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/tool-calls/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/tool-calls/get.ts
@@ -25,6 +25,8 @@ export type ManagementInstanceToolCallsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -41,6 +43,8 @@ export type ManagementInstanceToolCallsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -127,6 +131,8 @@ export let mapManagementInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -164,6 +170,8 @@ export let mapManagementInstanceToolCallsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/tool-calls/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/management/instance/tool-calls/list.ts
@@ -26,6 +26,8 @@ export type ManagementInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -42,6 +44,8 @@ export type ManagementInstanceToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -140,6 +144,11 @@ export let mapManagementInstanceToolCallsListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -178,6 +187,11 @@ export let mapManagementInstanceToolCallsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/consumer-profiles/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/consumer-profiles/create.ts
@@ -1,0 +1,86 @@
+import { mtMap } from '@metorial/util-resource-mapper';
+
+export type PortalsConsumerProfilesCreateOutput = {
+  object: 'consumer.profile';
+  id: string;
+  name: string;
+  email: string;
+  imageUrl: string;
+  consumerId: string;
+  status: 'active' | 'invited';
+  createdAt: Date;
+  updatedAt: Date;
+} & {
+  groups:
+    | {
+        object: 'consumer.profile.group_assignment';
+        group: {
+          object: 'consumer.group';
+          id: string;
+          status: 'active' | 'archived' | 'deleted';
+          name: string;
+          description: string | null;
+          isDefault: boolean;
+          ssoGroupIds: string[];
+          createdAt: Date;
+          updatedAt: Date;
+        };
+        assignedVia: 'default' | 'manual' | 'sso' | 'user';
+      }[]
+    | null;
+};
+
+export let mapPortalsConsumerProfilesCreateOutput = mtMap.union([
+  mtMap.unionOption(
+    'object',
+    mtMap.object({
+      object: mtMap.objectField('object', mtMap.passthrough()),
+      id: mtMap.objectField('id', mtMap.passthrough()),
+      name: mtMap.objectField('name', mtMap.passthrough()),
+      email: mtMap.objectField('email', mtMap.passthrough()),
+      imageUrl: mtMap.objectField('image_url', mtMap.passthrough()),
+      consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
+      status: mtMap.objectField('status', mtMap.passthrough()),
+      createdAt: mtMap.objectField('created_at', mtMap.date()),
+      updatedAt: mtMap.objectField('updated_at', mtMap.date()),
+      groups: mtMap.objectField(
+        'groups',
+        mtMap.array(
+          mtMap.object({
+            object: mtMap.objectField('object', mtMap.passthrough()),
+            group: mtMap.objectField(
+              'group',
+              mtMap.object({
+                object: mtMap.objectField('object', mtMap.passthrough()),
+                id: mtMap.objectField('id', mtMap.passthrough()),
+                status: mtMap.objectField('status', mtMap.passthrough()),
+                name: mtMap.objectField('name', mtMap.passthrough()),
+                description: mtMap.objectField(
+                  'description',
+                  mtMap.passthrough()
+                ),
+                isDefault: mtMap.objectField('is_default', mtMap.passthrough()),
+                ssoGroupIds: mtMap.objectField(
+                  'sso_group_ids',
+                  mtMap.array(mtMap.passthrough())
+                ),
+                createdAt: mtMap.objectField('created_at', mtMap.date()),
+                updatedAt: mtMap.objectField('updated_at', mtMap.date())
+              })
+            ),
+            assignedVia: mtMap.objectField('assigned_via', mtMap.passthrough())
+          })
+        )
+      )
+    })
+  )
+]);
+
+export type PortalsConsumerProfilesCreateBody = { email: string; name: string };
+
+export let mapPortalsConsumerProfilesCreateBody =
+  mtMap.object<PortalsConsumerProfilesCreateBody>({
+    email: mtMap.objectField('email', mtMap.passthrough()),
+    name: mtMap.objectField('name', mtMap.passthrough())
+  });
+

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/consumer-profiles/index.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/consumer-profiles/index.ts
@@ -1,4 +1,5 @@
 export * from './assign-groups';
+export * from './create';
 export * from './get';
 export * from './list';
 export * from './unassign-groups';

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/create.ts
@@ -17,7 +17,11 @@ export type PortalsCreateOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -62,6 +66,12 @@ export let mapPortalsCreateOutput = mtMap.object<PortalsCreateOutput>({
       sessionExpiryTimeInSeconds: mtMap.objectField(
         'session_expiry_time_in_seconds',
         mtMap.passthrough()
+      ),
+      allowedRedirectUrlFilters: mtMap.objectField(
+        'allowed_redirect_url_filters',
+        mtMap.array(
+          mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+        )
       )
     })
   ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/delete.ts
@@ -17,7 +17,11 @@ export type PortalsDeleteOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -62,6 +66,12 @@ export let mapPortalsDeleteOutput = mtMap.object<PortalsDeleteOutput>({
       sessionExpiryTimeInSeconds: mtMap.objectField(
         'session_expiry_time_in_seconds',
         mtMap.passthrough()
+      ),
+      allowedRedirectUrlFilters: mtMap.objectField(
+        'allowed_redirect_url_filters',
+        mtMap.array(
+          mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+        )
       )
     })
   ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/get.ts
@@ -17,7 +17,11 @@ export type PortalsGetOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -62,6 +66,12 @@ export let mapPortalsGetOutput = mtMap.object<PortalsGetOutput>({
       sessionExpiryTimeInSeconds: mtMap.objectField(
         'session_expiry_time_in_seconds',
         mtMap.passthrough()
+      ),
+      allowedRedirectUrlFilters: mtMap.objectField(
+        'allowed_redirect_url_filters',
+        mtMap.array(
+          mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+        )
       )
     })
   ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/list.ts
@@ -18,7 +18,11 @@ export type PortalsListOutput = {
       allowedFileExtensions: string[];
       allowNonStandardDirectories: boolean;
     };
-    auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+    auth: {
+      object: 'portal.auth';
+      sessionExpiryTimeInSeconds: number;
+      allowedRedirectUrlFilters: { url: string }[];
+    };
     urls: { type: 'default'; url: string }[];
     createdAt: Date;
     updatedAt: Date;
@@ -72,6 +76,14 @@ export let mapPortalsListOutput = mtMap.object<PortalsListOutput>({
             sessionExpiryTimeInSeconds: mtMap.objectField(
               'session_expiry_time_in_seconds',
               mtMap.passthrough()
+            ),
+            allowedRedirectUrlFilters: mtMap.objectField(
+              'allowed_redirect_url_filters',
+              mtMap.array(
+                mtMap.object({
+                  url: mtMap.objectField('url', mtMap.passthrough())
+                })
+              )
             )
           })
         ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/portals/update.ts
@@ -17,7 +17,11 @@ export type PortalsUpdateOutput = {
     allowedFileExtensions: string[];
     allowNonStandardDirectories: boolean;
   };
-  auth: { object: 'portal.auth'; sessionExpiryTimeInSeconds: number };
+  auth: {
+    object: 'portal.auth';
+    sessionExpiryTimeInSeconds: number;
+    allowedRedirectUrlFilters: { url: string }[];
+  };
   urls: { type: 'default'; url: string }[];
   createdAt: Date;
   updatedAt: Date;
@@ -62,6 +66,12 @@ export let mapPortalsUpdateOutput = mtMap.object<PortalsUpdateOutput>({
       sessionExpiryTimeInSeconds: mtMap.objectField(
         'session_expiry_time_in_seconds',
         mtMap.passthrough()
+      ),
+      allowedRedirectUrlFilters: mtMap.objectField(
+        'allowed_redirect_url_filters',
+        mtMap.array(
+          mtMap.object({ url: mtMap.objectField('url', mtMap.passthrough()) })
+        )
       )
     })
   ),

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/create.ts
@@ -9,6 +9,8 @@ export type SessionTemplatesCreateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapSessionTemplatesCreateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/delete.ts
@@ -9,6 +9,8 @@ export type SessionTemplatesDeleteOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapSessionTemplatesDeleteOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/get.ts
@@ -9,6 +9,8 @@ export type SessionTemplatesGetOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapSessionTemplatesGetOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/list.ts
@@ -10,6 +10,8 @@ export type SessionTemplatesListOutput = {
     metadata: Record<string, any> | null;
     integrationInstanceId: string | null;
     integrationInstanceGroupId: string | null;
+    identityActorId: string | null;
+    identityId: string | null;
     providers: {
       object: 'session.template.provider';
       id: string;
@@ -82,6 +84,11 @@ export let mapSessionTemplatesListOutput =
             'integration_instance_group_id',
             mtMap.passthrough()
           ),
+          identityActorId: mtMap.objectField(
+            'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
           providers: mtMap.objectField(
             'providers',
             mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/session-templates/update.ts
@@ -9,6 +9,8 @@ export type SessionTemplatesUpdateOutput = {
   metadata: Record<string, any> | null;
   integrationInstanceId: string | null;
   integrationInstanceGroupId: string | null;
+  identityActorId: string | null;
+  identityId: string | null;
   providers: {
     object: 'session.template.provider';
     id: string;
@@ -75,6 +77,11 @@ export let mapSessionTemplatesUpdateOutput =
       'integration_instance_group_id',
       mtMap.passthrough()
     ),
+    identityActorId: mtMap.objectField(
+      'identity_actor_id',
+      mtMap.passthrough()
+    ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
     providers: mtMap.objectField(
       'providers',
       mtMap.array(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/connections/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/connections/get.ts
@@ -27,6 +27,8 @@ export type SessionsConnectionsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -98,6 +100,8 @@ export let mapSessionsConnectionsGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/connections/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/connections/list.ts
@@ -28,6 +28,8 @@ export type SessionsConnectionsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -112,6 +114,11 @@ export let mapSessionsConnectionsListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/create.ts
@@ -69,6 +69,8 @@ export type SessionsCreateOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -212,6 +214,8 @@ export let mapSessionsCreateOutput = mtMap.object<SessionsCreateOutput>({
   ),
   hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
   hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+  identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+  identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
   createdAt: mtMap.objectField('created_at', mtMap.date()),
   updatedAt: mtMap.objectField('updated_at', mtMap.date())
 });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/delete.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/delete.ts
@@ -69,6 +69,8 @@ export type SessionsDeleteOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -212,6 +214,8 @@ export let mapSessionsDeleteOutput = mtMap.object<SessionsDeleteOutput>({
   ),
   hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
   hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+  identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+  identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
   createdAt: mtMap.objectField('created_at', mtMap.date()),
   updatedAt: mtMap.objectField('updated_at', mtMap.date())
 });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/events/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/events/get.ts
@@ -44,6 +44,8 @@ export type SessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -123,6 +125,8 @@ export type SessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -139,6 +143,8 @@ export type SessionsEventsGetOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -196,6 +202,8 @@ export type SessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -212,6 +220,8 @@ export type SessionsEventsGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -326,6 +336,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
           ),
           identityActorId: mtMap.objectField(
             'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
             mtMap.passthrough()
           ),
           agentClientId: mtMap.objectField(
@@ -478,6 +493,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -516,6 +536,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(
@@ -642,6 +667,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
             'identity_actor_id',
             mtMap.passthrough()
           ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
+            mtMap.passthrough()
+          ),
           agentClientId: mtMap.objectField(
             'agent_client_id',
             mtMap.passthrough()
@@ -677,6 +707,11 @@ export let mapSessionsEventsGetOutput = mtMap.object<SessionsEventsGetOutput>({
           ),
           identityActorId: mtMap.objectField(
             'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
             mtMap.passthrough()
           ),
           agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/events/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/events/list.ts
@@ -45,6 +45,8 @@ export type SessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -124,6 +126,8 @@ export type SessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -140,6 +144,8 @@ export type SessionsEventsListOutput = {
           agentId: string | null;
           agentInstanceId: string | null;
           identityActorId: string | null;
+          identityId: string | null;
+          agentActorId: string | null;
           agentClientId: string | null;
           consumerId: string | null;
           createdAt: Date;
@@ -200,6 +206,8 @@ export type SessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -216,6 +224,8 @@ export type SessionsEventsListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -349,6 +359,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -540,6 +558,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                         'identity_actor_id',
                         mtMap.passthrough()
                       ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
+                        mtMap.passthrough()
+                      ),
                       agentClientId: mtMap.objectField(
                         'agent_client_id',
                         mtMap.passthrough()
@@ -590,6 +616,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                       ),
                       identityActorId: mtMap.objectField(
                         'identity_actor_id',
+                        mtMap.passthrough()
+                      ),
+                      identityId: mtMap.objectField(
+                        'identity_id',
+                        mtMap.passthrough()
+                      ),
+                      agentActorId: mtMap.objectField(
+                        'agent_actor_id',
                         mtMap.passthrough()
                       ),
                       agentClientId: mtMap.objectField(
@@ -749,6 +783,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -796,6 +838,14 @@ export let mapSessionsEventsListOutput = mtMap.object<SessionsEventsListOutput>(
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/get.ts
@@ -69,6 +69,8 @@ export type SessionsGetOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -212,6 +214,8 @@ export let mapSessionsGetOutput = mtMap.object<SessionsGetOutput>({
   ),
   hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
   hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+  identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+  identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
   createdAt: mtMap.objectField('created_at', mtMap.date()),
   updatedAt: mtMap.objectField('updated_at', mtMap.date())
 });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/list.ts
@@ -70,6 +70,8 @@ export type SessionsListOutput = {
     fromTemplatesIds: string[];
     hasErrors: boolean;
     hasWarnings: boolean;
+    identityActorId: string | null;
+    identityId: string | null;
     createdAt: Date;
     updatedAt: Date;
   }[];
@@ -243,6 +245,11 @@ export let mapSessionsListOutput = mtMap.object<SessionsListOutput>({
         ),
         hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
         hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+        identityActorId: mtMap.objectField(
+          'identity_actor_id',
+          mtMap.passthrough()
+        ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
         createdAt: mtMap.objectField('created_at', mtMap.date()),
         updatedAt: mtMap.objectField('updated_at', mtMap.date())
       })

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/messages/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/messages/get.ts
@@ -57,6 +57,8 @@ export type SessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -73,6 +75,8 @@ export type SessionsMessagesGetOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -124,6 +128,8 @@ export type SessionsMessagesGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -140,6 +146,8 @@ export type SessionsMessagesGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -277,6 +285,11 @@ export let mapSessionsMessagesGetOutput =
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -315,6 +328,11 @@ export let mapSessionsMessagesGetOutput =
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(
@@ -438,6 +456,8 @@ export let mapSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()
@@ -475,6 +495,8 @@ export let mapSessionsMessagesGetOutput =
           'identity_actor_id',
           mtMap.passthrough()
         ),
+        identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+        agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
         agentClientId: mtMap.objectField(
           'agent_client_id',
           mtMap.passthrough()

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/messages/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/messages/list.ts
@@ -58,6 +58,8 @@ export type SessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -74,6 +76,8 @@ export type SessionsMessagesListOutput = {
         agentId: string | null;
         agentInstanceId: string | null;
         identityActorId: string | null;
+        identityId: string | null;
+        agentActorId: string | null;
         agentClientId: string | null;
         consumerId: string | null;
         createdAt: Date;
@@ -131,6 +135,8 @@ export type SessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -147,6 +153,8 @@ export type SessionsMessagesListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -302,6 +310,14 @@ export let mapSessionsMessagesListOutput =
                     'identity_actor_id',
                     mtMap.passthrough()
                   ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
+                    mtMap.passthrough()
+                  ),
                   agentClientId: mtMap.objectField(
                     'agent_client_id',
                     mtMap.passthrough()
@@ -349,6 +365,14 @@ export let mapSessionsMessagesListOutput =
                   ),
                   identityActorId: mtMap.objectField(
                     'identity_actor_id',
+                    mtMap.passthrough()
+                  ),
+                  identityId: mtMap.objectField(
+                    'identity_id',
+                    mtMap.passthrough()
+                  ),
+                  agentActorId: mtMap.objectField(
+                    'agent_actor_id',
                     mtMap.passthrough()
                   ),
                   agentClientId: mtMap.objectField(
@@ -490,6 +514,11 @@ export let mapSessionsMessagesListOutput =
                 'identity_actor_id',
                 mtMap.passthrough()
               ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
+                mtMap.passthrough()
+              ),
               agentClientId: mtMap.objectField(
                 'agent_client_id',
                 mtMap.passthrough()
@@ -528,6 +557,11 @@ export let mapSessionsMessagesListOutput =
               ),
               identityActorId: mtMap.objectField(
                 'identity_actor_id',
+                mtMap.passthrough()
+              ),
+              identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+              agentActorId: mtMap.objectField(
+                'agent_actor_id',
                 mtMap.passthrough()
               ),
               agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/participants/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/participants/get.ts
@@ -12,6 +12,8 @@ export type SessionsParticipantsGetOutput = {
   agentId: string | null;
   agentInstanceId: string | null;
   identityActorId: string | null;
+  identityId: string | null;
+  agentActorId: string | null;
   agentClientId: string | null;
   consumerId: string | null;
   createdAt: Date;
@@ -42,6 +44,8 @@ export let mapSessionsParticipantsGetOutput =
       'identity_actor_id',
       mtMap.passthrough()
     ),
+    identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+    agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
     agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
     consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
     createdAt: mtMap.objectField('created_at', mtMap.date())

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/participants/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/participants/list.ts
@@ -13,6 +13,8 @@ export type SessionsParticipantsListOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -50,6 +52,11 @@ export let mapSessionsParticipantsListOutput =
           ),
           identityActorId: mtMap.objectField(
             'identity_actor_id',
+            mtMap.passthrough()
+          ),
+          identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+          agentActorId: mtMap.objectField(
+            'agent_actor_id',
             mtMap.passthrough()
           ),
           agentClientId: mtMap.objectField(

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/update.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/sessions/update.ts
@@ -69,6 +69,8 @@ export type SessionsUpdateOutput = {
   fromTemplatesIds: string[];
   hasErrors: boolean;
   hasWarnings: boolean;
+  identityActorId: string | null;
+  identityId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -212,6 +214,8 @@ export let mapSessionsUpdateOutput = mtMap.object<SessionsUpdateOutput>({
   ),
   hasErrors: mtMap.objectField('has_errors', mtMap.passthrough()),
   hasWarnings: mtMap.objectField('has_warnings', mtMap.passthrough()),
+  identityActorId: mtMap.objectField('identity_actor_id', mtMap.passthrough()),
+  identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
   createdAt: mtMap.objectField('created_at', mtMap.date()),
   updatedAt: mtMap.objectField('updated_at', mtMap.date())
 });

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/tool-calls/create.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/tool-calls/create.ts
@@ -25,6 +25,8 @@ export type ToolCallsCreateOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -41,6 +43,8 @@ export type ToolCallsCreateOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -123,6 +127,8 @@ export let mapToolCallsCreateOutput = mtMap.object<ToolCallsCreateOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())
@@ -154,6 +160,8 @@ export let mapToolCallsCreateOutput = mtMap.object<ToolCallsCreateOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/tool-calls/get.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/tool-calls/get.ts
@@ -25,6 +25,8 @@ export type ToolCallsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -41,6 +43,8 @@ export type ToolCallsGetOutput = {
     agentId: string | null;
     agentInstanceId: string | null;
     identityActorId: string | null;
+    identityId: string | null;
+    agentActorId: string | null;
     agentClientId: string | null;
     consumerId: string | null;
     createdAt: Date;
@@ -123,6 +127,8 @@ export let mapToolCallsGetOutput = mtMap.object<ToolCallsGetOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())
@@ -154,6 +160,8 @@ export let mapToolCallsGetOutput = mtMap.object<ToolCallsGetOutput>({
         'identity_actor_id',
         mtMap.passthrough()
       ),
+      identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+      agentActorId: mtMap.objectField('agent_actor_id', mtMap.passthrough()),
       agentClientId: mtMap.objectField('agent_client_id', mtMap.passthrough()),
       consumerId: mtMap.objectField('consumer_id', mtMap.passthrough()),
       createdAt: mtMap.objectField('created_at', mtMap.date())

--- a/sdk/gen/src/mt_2026_01_01_magnetar/resources/tool-calls/list.ts
+++ b/sdk/gen/src/mt_2026_01_01_magnetar/resources/tool-calls/list.ts
@@ -26,6 +26,8 @@ export type ToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -42,6 +44,8 @@ export type ToolCallsListOutput = {
       agentId: string | null;
       agentInstanceId: string | null;
       identityActorId: string | null;
+      identityId: string | null;
+      agentActorId: string | null;
       agentClientId: string | null;
       consumerId: string | null;
       createdAt: Date;
@@ -139,6 +143,11 @@ export let mapToolCallsListOutput = mtMap.object<ToolCallsListOutput>({
               'identity_actor_id',
               mtMap.passthrough()
             ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
+              mtMap.passthrough()
+            ),
             agentClientId: mtMap.objectField(
               'agent_client_id',
               mtMap.passthrough()
@@ -177,6 +186,11 @@ export let mapToolCallsListOutput = mtMap.object<ToolCallsListOutput>({
             ),
             identityActorId: mtMap.objectField(
               'identity_actor_id',
+              mtMap.passthrough()
+            ),
+            identityId: mtMap.objectField('identity_id', mtMap.passthrough()),
+            agentActorId: mtMap.objectField(
+              'agent_actor_id',
               mtMap.passthrough()
             ),
             agentClientId: mtMap.objectField(

--- a/sdk/sdk/package.json
+++ b/sdk/sdk/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.1",
+    "@metorial/core": "^3.0.2",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/util-endpoint": "^3.0.0",
     "@metorial/anthropic": "^3.0.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly additive, generated-client updates (new endpoints/fields) plus dependency/version bumps; low risk aside from potential downstream type expectation changes in consumers.
> 
> **Overview**
> Updates package versions across MCP adapters and the SDK (`@metorial/core` to `3.0.2`, `@metorial/generated` to `3.0.2`) and syncs generated API clients.
> 
> Adds new `getEnv` endpoints and resource mappers for custom providers and custom provider versions (including dashboard/management instance variants), plus a new `create` endpoint for portal consumer profiles.
> 
> Extends multiple session/session-template/tool-call/event/participant outputs to include `identityActorId`/`identityId` and `agentActorId` metadata, and expands portal `auth` outputs to include `allowedRedirectUrlFilters`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2556352af49db11ad100eda1b2e7a32a07d5442b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->