### PR TITLE
Add portals types

### DIFF
--- a/mcp/ai-sdk/package.json
+++ b/mcp/ai-sdk/package.json
@@ -35,7 +35,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "zod": "^3.22.4"

--- a/mcp/anthropic/package.json
+++ b/mcp/anthropic/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/deepseek/package.json
+++ b/mcp/deepseek/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/google/package.json
+++ b/mcp/google/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/langchain/package.json
+++ b/mcp/langchain/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "zod": "^3.22.4"

--- a/mcp/mcp-session/package.json
+++ b/mcp/mcp-session/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@metorial/json-schema": "^3.0.0",
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/generated": "^3.0.2",
     "@metorial/util-endpoint": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.12.1",

--- a/mcp/mistral/package.json
+++ b/mcp/mistral/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1"
   },

--- a/mcp/openai-compatible/package.json
+++ b/mcp/openai-compatible/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1"
   },

--- a/mcp/openai/package.json
+++ b/mcp/openai/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/togetherai/package.json
+++ b/mcp/togetherai/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/mcp/xai/package.json
+++ b/mcp/xai/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-sdk-utils": "^3.0.1",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/openai-compatible": "^3.0.1"

--- a/packages/mcp-sdk-utils/package.json
+++ b/packages/mcp-sdk-utils/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-session": "^3.0.1"
   },
   "peerDependencies": {

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metorial/core",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "Metorial Inc.",
   "license": "MIT",
   "type": "module",

--- a/sdk/core/src/index.ts
+++ b/sdk/core/src/index.ts
@@ -104,4 +104,11 @@ export namespace MetorialSDK {
   export type MagicMcpSession = MetorialGenerated.MagicMcpSessionsGetOutput;
   export type MagicMcpToken = MetorialGenerated.MagicMcpTokensGetOutput;
   export type MagicMcpEndpoint = MetorialGenerated.MagicMcpEndpointsGetOutput;
+
+  export type Portal = MetorialGenerated.PortalsGetOutput;
+  export type PortalAccess = MetorialGenerated.PortalsAccessGetOutput;
+  export type PortalAccessRequest = MetorialGenerated.PortalsAccessRequestsGetOutput;
+  export type PortalAccessGroup = MetorialGenerated.PortalsConsumerGroupsGetOutput;
+  export type PortalAccessProfile = MetorialGenerated.PortalsConsumerProfilesGetOutput;
+  export type PortalAccessInvite = MetorialGenerated.PortalsConsumerInvitesGetOutput;
 }

--- a/sdk/sdk/package.json
+++ b/sdk/sdk/package.json
@@ -29,7 +29,7 @@
     "dist"
   ],
   "dependencies": {
-    "@metorial/core": "^3.0.2",
+    "@metorial/core": "^3.0.3",
     "@metorial/mcp-session": "^3.0.1",
     "@metorial/util-endpoint": "^3.0.0",
     "@metorial/anthropic": "^3.0.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly type-surface expansion and a patch version bump of `@metorial/core` propagated to dependent packages; low likelihood of runtime impact beyond dependency resolution.
> 
> **Overview**
> Adds new `MetorialSDK` type exports for portal entities (`Portal`, `PortalAccess`, `PortalAccessRequest`, and related consumer group/profile/invite types) in `@metorial/core`.
> 
> Bumps `@metorial/core` to `3.0.3` and updates all MCP and SDK package `package.json` files to depend on `^3.0.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bcd1ebad337c8bba7a5f9e8e3772021a88026ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->